### PR TITLE
Debug/pymongo errors

### DIFF
--- a/ccpncdb/search.py
+++ b/ccpncdb/search.py
@@ -137,7 +137,8 @@ def search_by_chemname(pattern):
         # regex = re.compile(sb.replace(".", "\\.").replace(
         # "*", ".*").replace("?", "."), re.IGNORECASE)
         regex = re.compile(sb.replace("*", ".*"), re.IGNORECASE)
-        sbquery = {'chemname': {'$regex': regex, '$options': 'i'}}
+        # sbquery = {'chemname': {'$regex': regex, '$options': 'i'}}
+        sbquery = {'chemname': {'$regex': regex}}
         query['$or'][0]['$and'].append(sbquery)
         pattern = pattern.replace('"{0}"'.format(sb), '')
 

--- a/ccpncdb/search.py
+++ b/ccpncdb/search.py
@@ -138,7 +138,7 @@ def search_by_chemname(pattern):
         # "*", ".*").replace("?", "."), re.IGNORECASE)
         regex = re.compile(sb.replace("*", ".*"), re.IGNORECASE)
         # sbquery = {'chemname': {'$regex': regex, '$options': 'i'}}
-        sbquery = {'chemname': {'$regex': regex}}
+        sbquery = {'chemname': {'$regex': regex}} #regex already includes re.IGNORECASE, setting $options to 'i' is redundant and causes an error
         query['$or'][0]['$and'].append(sbquery)
         pattern = pattern.replace('"{0}"'.format(sb), '')
 


### PR DESCRIPTION
Fixed code in search.py to avoid error in newer pymongo versions. Setting re.IGNORECASE in re.compile and also setting the case-insensitive search condition along with $regex will give rise to 'Operation failure' error from pymongo. The code has been amended to avoid this error and the user seeing an 'An unexpected error occurred' message.