### PR TITLE
Accessible popups

### DIFF
--- a/static/css/stylesheet.css
+++ b/static/css/stylesheet.css
@@ -524,3 +524,93 @@ input:checked + .slider .off
     background-color: #000; /* Change the color as needed */
     margin: 20px 0; /* Adjust the margin as needed */
 }
+
+
+/* Tooltip styles */
+.has-tooltip-arrow[data-tooltip] {
+    position: relative; /* Ensure the parent element is positioned relative */
+}
+
+.has-tooltip-arrow[data-tooltip]::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    z-index: 1000;
+    padding: 0.5em 1em;
+    white-space: pre-wrap;
+    background:#34495e;
+    color: #FFF;
+    border-radius: 3px;
+    font-size: 0.75em;
+    line-height: 1.25;
+    box-shadow: 0 2px 3px rgba(10, 10, 10, 0.1);
+    opacity: 0;
+    transition: opacity 1s;
+    width: 350px; /* Adjust the width as needed */
+    overflow: visible; /* Ensure content does not overflow */
+    pointer-events: none; /* Prevent the tooltip from capturing mouse events */
+}
+
+.has-tooltip-arrow[data-tooltip]:hover::after,
+.has-tooltip-arrow[data-tooltip]:focus::after {
+    opacity: 1;
+}
+
+/* Tooltip arrow pointing to the left */
+.tooltip-left[data-tooltip]::after {
+    top: 50%;
+    right: 100%;
+    transform: translateY(-50%);
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent #34495e transparent transparent;
+}
+
+/* Tooltip arrow pointing to the right */
+.tooltip-right[data-tooltip]::after {
+    top: 50%;
+    left: 100%;
+    transform: translateY(-50%);
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent transparent transparent #34495e;
+}
+ 
+/* Custom tooltip font size */
+.custom-tooltip[data-tooltip]::after {
+    font-size: 1em; /* Adjust the font size as needed */
+    font-weight: 400; /* Adjust the font weight as needed */
+}
+ 
+/* Icon styles */
+.icon.has-tooltip-arrow .fa-question-circle {
+    position: relative;
+    color: #34495e; /* Colour for the circle */
+    display: inline-flex; /* Align icon with text */
+    align-items: center; /* Center icon vertically */
+    justify-content: center; /* Center icon horizontally */
+    width: 1.2em;
+    height: 1.2em;
+    background: #fff; /* Background for the circle */
+    border-radius: 50%;
+}
+ 
+.icon.has-tooltip-arrow .fa-question-circle::before {
+    content: '\f059'; /* Unicode for question mark in Font Awesome */
+    font-family: 'Font Awesome 5 Free';
+    font-weight: 600;
+    position: relative;
+    color: #34495e; /* Colour for the question mark */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.1em; /* Adjust font size to scale with the circle */
+}
+
+.align-center {
+    display: flex;
+    align-items: center; /* Vertically center the items */
+}
+
+.switch {
+    margin-left: 5px; /* Add space between the tooltip and the BOOLEAN filter switch */
+}

--- a/static/index.html
+++ b/static/index.html
@@ -402,7 +402,7 @@
                                 <tr>
                                     <td colspan="1" rowspan="" headers="" style="vertical-align: middle; text-align: center;">
                                         Search pattern
-                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Search for a specific polymorph using Roman or Arabic numbering (e.g., &quot;Form I&quot; or &quot;Form 1&quot;) &#10; &#10; Try broadening search using wildcards (e.g., &quot;Form*&quot;)." style="margin-left: 5px;">
+                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Search for a specific polymorph using Roman or Arabic numbering (e.g., Form I or Form 1) &#10; &#10; Try broadening search using wildcards (e.g., Form*)." style="margin-left: 5px;">
                                             <i class="fas fa-question-circle"></i>
                                         </span>
                                     </td>
@@ -485,7 +485,7 @@
                                 <tr>
                                     <td colspan="1" rowspan="" headers="" style="vertical-align: middle; text-align: center;">
                                         External reference
-                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Choose the external database name from the dropdown list. If the database is not listed, select 'Other' and enter the database name manually. &#10; &#10;Enter the reference code in the 'Database code' field. Wilcards are permitted. For example, try QATMON for specific search or QATMON* for all polymorphic variations of the material." style="margin-left: 5px;">
+                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Choose the external database name from the dropdown list. If the database is not listed, select 'Other' and enter the database name manually. &#10; &#10;Enter the reference code in the 'Database code' field. Wildcards are permitted. For example, try QATMON for specific search or QATMON* for all polymorphic variations of the material." style="margin-left: 5px;">
                                             <i class="fas fa-question-circle"></i>
                                         </span>
                                     </td>

--- a/static/index.html
+++ b/static/index.html
@@ -243,6 +243,9 @@
                             <tr>
                                 <td class="width-1" colspan="1" rowspan="" headers="" style="vertical-align: middle; text-align: center;">
                                     Search type
+                                    <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Select your search criteria from the dropdown list."  style="margin-left: 5px;">
+                                        <i class="fas fa-question-circle"></i>
+                                    </span>
                                 </td>
                                 <td class="width-3" colspan="3" rowspan="" headers="">
                                     <div class="control is-pulled-right">
@@ -281,10 +284,13 @@
                                 <tr>
                                     <td colspan="1" rowspan="" headers="" style="vertical-align: middle; text-align: center;">
                                         Publication doi
+                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Enter a complete DOI for a publication where the structure was published e.g., 10.1016/j.ssnmr.2017.11.002.  &#10; &#10; Try using partial DOI with wildcards such as 10.1016* or *2017* to broaden search." style="margin-left: 5px;">
+                                            <i class="fas fa-question-circle"></i>
+                                        </span>
                                     </td>
                                     <td colspan="3" rowspan="" headers="">
                                         <div class="control">
-                                            <input class="input" type="text" placeholder="doi"
+                                            <input class="input" type="text" placeholder="Enter publication doi"
                                                 ng-model="search_spec.args.doi" ng-init="search_spec.args.doi = null">                        
                                         </div>
                                     </td>
@@ -294,6 +300,9 @@
                                 <tr>
                                     <td colspan="1" rowspan="" headers="" style="vertical-align: middle; text-align: center;">
                                         Species
+                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Enter an element symbol (e.g., H) to search for magnetic shielding values for that element."  style="margin-left: 5px;">
+                                            <i class="fas fa-question-circle"></i>
+                                        </span>
                                     </td>
                                     <td colspan="3" rowspan="" headers="">
                                         <div class="control">
@@ -305,6 +314,9 @@
                                 <tr>
                                     <td colspan="1" rowspan="" headers="" style="vertical-align: middle; text-align: center;">
                                         Min. MS value
+                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Specify an integer value. If left blank, the default value is 0." style="margin-left: 5px;">
+                                            <i class="fas fa-question-circle"></i>
+                                        </span>
                                     </td>
                                     <td colspan="1" rowspan="" headers="">
                                         <div class="control">                                        
@@ -314,6 +326,9 @@
                                     </td>
                                     <td colspan="1" rowspan="" headers="" style="vertical-align: middle; text-align: center;">
                                         Max. MS value
+                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Specify an integer value. If left blank, the default value is 0." style="margin-left: 5px;">
+                                            <i class="fas fa-question-circle"></i>
+                                        </span>
                                     </td>
                                     <td colspan="1" rowspan="" headers="">
                                         <div class="control">                                        
@@ -327,6 +342,9 @@
                                 <tr>
                                     <td colspan="1" rowspan="" headers="" style="vertical-align: middle; text-align: center;">
                                         Species
+                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Enter an element symbol (e.g., H) to search for electric field gradient values for that element."  style="margin-left: 5px;">
+                                            <i class="fas fa-question-circle"></i>
+                                        </span>
                                     </td>
                                     <td colspan="3" rowspan="" headers="">
                                         <div class="control">
@@ -338,6 +356,9 @@
                                 <tr>
                                     <td colspan="1" rowspan="" headers="" style="vertical-align: middle; text-align: center;">
                                         Min. EFG V<sub>zz</sub> value
+                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Specify an integer value. If left blank, the default value is 0."  style="margin-left: 5px;">
+                                            <i class="fas fa-question-circle"></i>
+                                        </span>
                                     </td>
                                     <td colspan="1" rowspan="" headers="">
                                         <div class="control">
@@ -347,6 +368,9 @@
                                     </td>
                                     <td colspan="1" rowspan="" headers="" style="vertical-align: middle; text-align: center;">
                                         Max. EFG V<sub>zz</sub> value
+                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Specify an integer value. If left blank, the default value is 0."  style="margin-left: 5px;">
+                                            <i class="fas fa-question-circle"></i>
+                                        </span>
                                     </td>
                                     <td colspan="1" rowspan="" headers="">
                                         <div class="control">
@@ -360,6 +384,9 @@
                                 <tr>
                                     <td colspan="1" rowspan="" headers="" style="vertical-align: middle; text-align: center;">
                                         Search pattern
+                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Try a simple free-text search (e.g., benzamide) to return both partial and exact chemical name matches to available compounds.  &#10; &#10;For exact matches, enter the full IUPAC name (e.g., 4-amino-N-(2-(dimethylamino)ethyl)benzamide).  &#10; &#10;Filter results using wilcards in &quot;&quot; (e.g., &quot;*benzamide&quot;)." style="margin-left: 5px;">
+                                            <i class="fas fa-question-circle"></i>
+                                        </span>
                                     </td>
                                     <td colspan="3" rowspan="" headers="">
                                         <div class="control">
@@ -375,6 +402,9 @@
                                 <tr>
                                     <td colspan="1" rowspan="" headers="" style="vertical-align: middle; text-align: center;">
                                         Search pattern
+                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Search for a specific polymorph using Roman or Arabic numbering (e.g., &quot;Form I&quot; or &quot;Form 1&quot;) &#10; &#10; Try broadening search using wildcards (e.g., &quot;Form*&quot;)." style="margin-left: 5px;">
+                                            <i class="fas fa-question-circle"></i>
+                                        </span>
                                     </td>
                                     <td colspan="3" rowspan="" headers="">
                                         <div class="control">
@@ -390,6 +420,9 @@
                                 <tr>
                                     <td colspan="1" rowspan="" headers="" style="vertical-align: middle; text-align: center;">
                                         Unit cell formula
+                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Enter the alphabetised chemical formula of the unit cell (e.g., O4Sn2, C6H6). &#10; &#10; Use standard element symbols with appropropriate capitalisation (e.g., Sn for Tin, not SN) followed by numeric subscripts." style="margin-left: 5px;">
+                                            <i class="fas fa-question-circle"></i>
+                                        </span>
                                     </td>
                                     <td colspan="3" rowspan="" headers="">
                                         <div class="control">
@@ -402,6 +435,9 @@
                                 <tr>
                                     <td colspan="1" rowspan="" headers="" style="vertical-align: middle; text-align: center;">
                                         Include systems with additional elements
+                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Check this box to find structures that contain your specified formula as a subset, even if additional elements not specified in the unit cell are present." style="margin-left: 5px;">
+                                            <i class="fas fa-question-circle"></i>
+                                        </span>
                                     </td>
                                     <td colspan="3" rowspan="" headers="">
                                         <div class="control is-pulled-right">
@@ -415,6 +451,9 @@
                                 <tr>
                                     <td colspan="1" rowspan="" headers="" style="vertical-align: middle; text-align: center;">
                                         Molecular formula
+                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Enter the alphabetised formula of a molecular fragment to search subsets of a structure (e.g., Searching for C6H12O6 glucose would return alpha-D-Galactose and Beta-D-Fructopyranose both of which contain this molecular fragment). &#10; &#10; Use standard element symbols with appropropriate capitalisation (e.g., Sn for Tin, not SN) followed by numeric subscripts." style="margin-left: 5px;">
+                                            <i class="fas fa-question-circle"></i>
+                                        </span>
                                     </td>
                                     <td colspan="3" rowspan="" headers="">
                                         <div class="control">
@@ -429,6 +468,9 @@
                                 <tr>
                                     <td colspan="1" rowspan="" headers="" style="vertical-align: middle; text-align: center;">
                                         MRD Reference
+                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Unique 7-digit Magres database reference number. Pad with leading zeros as applicable, for example, 0000001 or 0005210." style="margin-left: 5px;">
+                                            <i class="fas fa-question-circle"></i>
+                                        </span>
                                     </td>
                                     <td colspan="3" rowspan="" headers="">
                                         <div class="control">
@@ -443,6 +485,9 @@
                                 <tr>
                                     <td colspan="1" rowspan="" headers="" style="vertical-align: middle; text-align: center;">
                                         External reference
+                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Choose the external database name from the dropdown list. If the database is not listed, select 'Other' and enter the database name manually. &#10; &#10;Enter the reference code in the 'Database code' field. Wilcards are permitted. For example, try QATMON for specific search or QATMON* for all polymorphic variations of the material." style="margin-left: 5px;">
+                                            <i class="fas fa-question-circle"></i>
+                                        </span>
                                     </td>
                                     <!-- Database name can be chosen from dropdown list or 'Other' option chosen to enter name manually -->
                                     <td colspan="1" rowspan="" headers="">
@@ -489,6 +534,9 @@
                                 <tr>
                                     <td colspan="1" rowspan="" headers="" style="vertical-align: middle; text-align: center;">
                                         License
+                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-right" data-tooltip="Choose a data attribution license from the dropdown list." style="margin-left: 5px;">
+                                            <i class="fas fa-question-circle"></i>
+                                        </span>
                                     </td>
                                     <td colspan="3" rowspan="" headers="">
                                         <div class="control is-pulled-right">
@@ -510,7 +558,10 @@
                                 <td colspan="4">
                                     <!--Add a toggle switch to allow the user to switch between AND and NOT search-->
                                     <!-- Default search is AND with toggle switch 'off', NOT corresponds to toggle 'on' -->
-                                    <div class="control is-pulled-right">
+                                    <div class="control is-pulled-right align-center">
+                                        <span class="icon has-tooltip-arrow has-tooltip-info has-tooltip-multiline custom-tooltip tooltip-left" data-tooltip="BOOLEAN Filter. See FAQs section for usage instructions." style="margin-right: 5px;">
+                                            <i class="fas fa-question-circle"></i>
+                                        </span>
                                         <label class="switch">
                                             <input type="checkbox" ng-model="search_spec.negate_query">
                                             <span class="slider round">

--- a/static/templates/version_table.html
+++ b/static/templates/version_table.html
@@ -38,7 +38,7 @@
     <td colspan="" rowspan="" headers="">
         <div class="field is-grouped">
             <div class="control">
-                <input class="input" type="text" size="20"
+                <input class="input" type="text" size="40"
                     name="extref_code" ng-model="versionTable.extref_code"
                     placeholder="Code for external database">            
             </div>


### PR DESCRIPTION
Interactive help regarding the usage of the search form fields are introduced into the form itself in the form of question mark tooltips that the users can hover over with their mouse to read help text. The need for these pop-ups were reviewed for the uploads page, but it was decided that the placeholder text in the uploads form is descriptive enough along with the upload instructions written up in the case of bulk uploads. Therefore, this feature is not introduced for the uploads page.

The accessibility of the buttons have been evaluated using the WAVE evaluation tool and found to pass requirements.

The content of the pop-up boxes has been sent to Paul and Steven for comments. Steven has okayed the contents.